### PR TITLE
Add "exclude" option to exclude specific collections

### DIFF
--- a/bin/firestore-backup.js
+++ b/bin/firestore-backup.js
@@ -23,12 +23,22 @@ var databaseStartPathParamDescription = 'The database collection or document pat
 var requestCountLimitParamKey = 'requestCountLimit'
 var requestCountLimitParamDescription = 'The maximum number of requests to be made in parallel.'
 
+var excludeParamKey = 'exclude'
+var excludeParamDescription = 'Collection(s) to exclude from backing up.'
+
+// This allows taking an array of collections to exclude, e.g. `firestore-backup -E logs -E events`
+function collectAllExcludeValues(str, memo) {
+  memo.push(str)
+  return memo
+}
+
 commander.version('1.0.1')
   .option('-a, --' + accountCredentialsPathParamKey + ' <path>', accountCredentialsPathParamDescription)
   .option('-B, --' + backupPathParamKey + ' <path>', backupPathParamDescription)
   .option('-P, --' + prettyPrintParamKey, prettyPrintParamDescription)
   .option('-S, --' + databaseStartPathParamKey + ' <path>', databaseStartPathParamDescription)
   .option('-L, --' + requestCountLimitParamKey + ' <number>', requestCountLimitParamDescription)
+  .option('-E', '--' + excludeParamKey, excludeParamDescription, collectAllExcludeValues, [])
   .parse(process.argv)
 
 const accountCredentialsPath = commander[accountCredentialsPathParamKey]
@@ -57,6 +67,8 @@ const databaseStartPath = (commander[databaseStartPathParamKey] || '').replace(/
 
 const requestCountLimit = parseInt(commander[requestCountLimitParamKey] || '1', 10)
 
+const exclude = commander[excludeParamKey] || []
+
 var firestoreBackup = require('../dist/index.js')
 try {
   console.time('backuptime')
@@ -65,7 +77,8 @@ try {
     databaseStartPath,
     backupPath,
     prettyPrintJSON,
-    requestCountLimit
+    requestCountLimit,
+    exclude
   })
     .then(() => {
       console.log(colors.bold(colors.green('All done 💫')))

--- a/dist/firestore.js
+++ b/dist/firestore.js
@@ -114,7 +114,8 @@ var constructDocumentValue = exports.constructDocumentValue = function construct
 
 var defaultBackupOptions = {
   databaseStartPath: '',
-  requestCountLimit: 1
+  requestCountLimit: 1,
+  exclude: []
 };
 
 var FirestoreBackup = exports.FirestoreBackup = function () {
@@ -154,6 +155,9 @@ var FirestoreBackup = exports.FirestoreBackup = function () {
 
       return this.options.database.getCollections().then(function (collections) {
         return (0, _utility.promiseParallel)(collections, function (collection) {
+          if (_this2.options.exclude.includes(collection.id)) {
+            return Promise.resolve();
+          }
           return _this2.backupCollection(collection, _this2.options.backupPath + '/' + collection.id, '/');
         }, 1);
       });

--- a/dist/firestore.js.flow
+++ b/dist/firestore.js.flow
@@ -118,7 +118,8 @@ export const constructDocumentValue = (documentDataToStore: Object = {}, keys: A
 
 const defaultBackupOptions = {
   databaseStartPath: '',
-  requestCountLimit: 1
+  requestCountLimit: 1,
+  exclude: []
 }
 
 export class FirestoreBackup {
@@ -155,6 +156,9 @@ export class FirestoreBackup {
     return this.options.database.getCollections()
       .then((collections) => {
         return promiseParallel(collections, (collection) => {
+          if (this.options.exclude.includes(collection.id)) {
+            return Promise.resolve();
+          }
           return this.backupCollection(collection, this.options.backupPath + '/' + collection.id, '/')
         }, 1)
       })

--- a/dist/types.js.flow
+++ b/dist/types.js.flow
@@ -17,7 +17,8 @@ export type BackupOptions = {|
   backupPath: string,
   databaseStartPath: string,
   prettyPrintJSON: boolean,
-  requestCountLimit: number
+  requestCountLimit: number,
+  exclude: Array<string>
 |}
 
 // Returns if a value is a string

--- a/lib/firestore.js
+++ b/lib/firestore.js
@@ -118,7 +118,8 @@ export const constructDocumentValue = (documentDataToStore: Object = {}, keys: A
 
 const defaultBackupOptions = {
   databaseStartPath: '',
-  requestCountLimit: 1
+  requestCountLimit: 1,
+  exclude: []
 }
 
 export class FirestoreBackup {
@@ -155,6 +156,9 @@ export class FirestoreBackup {
     return this.options.database.getCollections()
       .then((collections) => {
         return promiseParallel(collections, (collection) => {
+          if (this.options.exclude.includes(collection.id)) {
+            return Promise.resolve();
+          }
           return this.backupCollection(collection, this.options.backupPath + '/' + collection.id, '/')
         }, 1)
       })

--- a/lib/types.js
+++ b/lib/types.js
@@ -17,7 +17,8 @@ export type BackupOptions = {|
   backupPath: string,
   databaseStartPath: string,
   prettyPrintJSON: boolean,
-  requestCountLimit: number
+  requestCountLimit: number,
+  exclude: Array<string>
 |}
 
 // Returns if a value is a string


### PR DESCRIPTION
This tool is great!

I only have one shortcoming, I have a giant "events" collection that I don't want backed up. I added a "-E" option so you can exclude individual collections from being backed up

This is also useful for people who may have other large collections that may not be desired to be backed up such as `logs` 