### PR TITLE
Fix passing databaseStartPath as a parameter.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7,7 +7,7 @@ Object.defineProperty(exports, "__esModule", {
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 exports.default = function (_options) {
-  var options = Object.assign({}, _options, { databaseStartPath: '' });
+  var options = Object.assign({ databaseStartPath: '' }, _options);
 
   var accountCredentialsContents = void 0;
   if (typeof options.accountCredentials === 'string') {

--- a/dist/index.js.flow
+++ b/dist/index.js.flow
@@ -17,7 +17,7 @@ export type BackupOptions = {|
 |}
 
 export default function(_options: BackupOptions) {
-  const options = Object.assign({}, _options, {databaseStartPath: ''})
+  const options = Object.assign({databaseStartPath: ''}, _options)
 
   let accountCredentialsContents: Object
   if (typeof options.accountCredentials === 'string') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ export type BackupOptions = {|
 |}
 
 export default function(_options: BackupOptions) {
-  const options = Object.assign({}, _options, {databaseStartPath: ''})
+  const options = Object.assign({databaseStartPath: ''}, _options)
 
   let accountCredentialsContents: Object
   if (typeof options.accountCredentials === 'string') {


### PR DESCRIPTION
Resolves: https://github.com/steadyequipment/node-firestore-backup/issues/29

Output of new job:
```
$ node bin/firestore-backup.js -B backup -S /organizations/org-id-1
Starting backup...
Using start path ' organizations/org-id-1 '
Backing up Document '/org-id-1'
...
```