### PR TITLE
fixes `--prettyPrint`, uses flag from command line options correctly

### DIFF
--- a/dist/firestore.js
+++ b/dist/firestore.js
@@ -234,8 +234,8 @@ var FirestoreBackup = exports.FirestoreBackup = function () {
         var keys = Object.keys(documentData);
         var documentDataToStore = {};
         documentDataToStore = Object.assign({}, constructDocumentValue(documentDataToStore, keys, documentData));
-        if (this.prettyPrintJSON === true) {
-          fileContents = (0, _jsonStableStringify2.default)(documentDataToStore, null, 2);
+        if (this.options.prettyPrintJSON === true) {
+          fileContents = (0, _jsonStableStringify2.default)(documentDataToStore, {space: 2});
         } else {
           fileContents = (0, _jsonStableStringify2.default)(documentDataToStore);
         }


### PR DESCRIPTION
and passes the ident spaces number as an options hash as expected by json-stable-stringify.