### PR TITLE
Add --requestCountLimit in basic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This downloaded json file contains the proper credentials needed for __firestore
 
 Example:
 ```sh
-firestore-backup --accountCredentials path/to/credentials/file.json --backupPath /backups/myDatabase
+firestore-backup --accountCredentials path/to/credentials/file.json --backupPath /backups/myDatabase --requestCountLimit 50
 ```
 
 ### Backup with pretty printing:


### PR DESCRIPTION
# Why I'm doing this PR?
Most of time (just a User Experience revelation) users only use the first "basic example" shown in the README file. For example: Me.

All my backups took more than 5 hours only because I never saw the `--requestCountLimit` documentation. Maybe there are more folks like me there in the wild internet. Let's help them :)