### PR TITLE
add ability to fetch collections in batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ Example:
 firestore-backup --accountCredentials path/to/credentials/file.json --backupPath /backups/myDatabase --excludePattern '^/collectionToIgnore' --excludePattern '^/[^/]*/[^/]*/subcollectionToIgnore'
 ```
 
+### Fetch documents in batches:
+* `--batchSize` `<number` - The maximum number of documents to fetch in a single request.
+
+Example:
+```sh
+firestore-backup --accountCredentials path/to/credentials/file.json --backupPath /backups/myDatabase --batchSize 25
+```
+
 ### Relax:
 That's it! ✨🌈
 

--- a/bin/firestore-backup.js
+++ b/bin/firestore-backup.js
@@ -30,6 +30,9 @@ var excludeParamDescription = 'Top level collection id(s) to exclude from backin
 var excludePatternParamKey = 'excludePattern'
 var excludePatternParamDescription = 'Documents and collections whose paths match the regex to exclude from backing up. Can be provided multiple times.'
 
+var batchSizeParamKey = 'batchSize'
+var batchSizeParamDescription = 'The maximum number of documents to fetch in a single request.'
+
 const collectAllValues = (addValue/*: string */, toValues/*: Array<string> */)/*: Array<string> */ => {
   toValues.push(addValue)
   return toValues
@@ -42,6 +45,7 @@ commander.version('2.3.0')
   .option('-S, --' + databaseStartPathParamKey + ' <path>', databaseStartPathParamDescription)
   .option('-L, --' + requestCountLimitParamKey + ' <number>', requestCountLimitParamDescription)
   .option('-E, --' + excludeParamKey + ' <path>', excludeParamDescription, collectAllValues, [])
+  .option('--' + batchSizeParamKey + ' <number>', batchSizeParamDescription)
   .option('--' + excludePatternParamKey + ' <regex>', excludePatternParamDescription, collectAllValues, [])
   .parse(process.argv)
 
@@ -75,6 +79,8 @@ const exclude = commander[excludeParamKey] || []
 
 const excludePatterns = commander[excludePatternParamKey].map(pattern => new RegExp(pattern)) || []
 
+const batchSize = parseInt(commander[batchSizeParamKey] || '-1', 10)
+
 var firestoreBackup = require('../dist/index.js')
 try {
   console.time('backuptime')
@@ -85,7 +91,8 @@ try {
     prettyPrintJSON,
     requestCountLimit,
     exclude,
-    excludePatterns
+    excludePatterns,
+    batchSize
   })
     .then(() => {
       console.log(colors.bold(colors.green('All done 💫')))

--- a/dist/firestore.js.flow
+++ b/dist/firestore.js.flow
@@ -120,7 +120,8 @@ const defaultBackupOptions = {
   databaseStartPath: '',
   requestCountLimit: 1,
   exclude: [],
-  excludePatterns: []
+  excludePatterns: [],
+  batchSize: -1
 }
 
 export class FirestoreBackup {
@@ -197,13 +198,28 @@ export class FirestoreBackup {
     } catch (error) {
       throw new Error('Unable to create backup path for Collection \'' + collection.id + '\': ' + error)
     }
+    return this.batchCollection(collection, backupPath, logPathWithCollection, this.options.batchSize)
+  }
 
-    return collection.get()
-      .then((documentSnapshots) => documentSnapshots.docs)
-      .then((docs) => {
-        return promiseParallel(docs, (document) => {
+  batchCollection(collection: Object, backupPath: string, logPathWithCollection: string,  batchSize: number, cursor ?: Object) {
+    const batchRequested = batchSize > 0;
+    var collectionQuery = cursor ? collection.startAfter(cursor) : collection;
+    if (batchRequested) {
+      collectionQuery = collectionQuery.limit(batchSize)
+    }
+    return collectionQuery.get()
+      .then(documentSnapshots => documentSnapshots.docs)
+      .then(docs => {
+        return promiseParallel(docs, document => {
           return this.backupDocument(document, backupPath + '/' + document.id, logPathWithCollection + '/')
         }, this.options.requestCountLimit)
+        .then(() => {
+          if (batchRequested && docs.length === batchSize) {
+            return this.batchCollection(collection, backupPath, logPathWithCollection, batchSize, docs[docs.length - 1])
+          } else {
+            return Promise.resolve();
+          }
+        })
       })
   }
 

--- a/dist/index.js.flow
+++ b/dist/index.js.flow
@@ -18,7 +18,8 @@ export type BackupOptions = {|
   prettyPrintJSON: boolean,
   requestCountLimit: number,
   exclude: Array<string>,
-  excludePatterns: Array<RegExp>
+  excludePatterns: Array<RegExp>,
+  batchSize: number
 |}
 
 export default function(_options: BackupOptions) {

--- a/dist/types.js.flow
+++ b/dist/types.js.flow
@@ -18,7 +18,8 @@ export type FirestoreBackupOptions = {|
   databaseStartPath: string,
   prettyPrintJSON: boolean,
   requestCountLimit: number,
-  exclude: Array<string>
+  exclude: Array<string>,
+  batchSize: number
 |}
 
 // Returns if a value is a string

--- a/lib/firestore.js
+++ b/lib/firestore.js
@@ -120,7 +120,8 @@ const defaultBackupOptions = {
   databaseStartPath: '',
   requestCountLimit: 1,
   exclude: [],
-  excludePatterns: []
+  excludePatterns: [],
+  batchSize: -1
 }
 
 export class FirestoreBackup {
@@ -197,13 +198,28 @@ export class FirestoreBackup {
     } catch (error) {
       throw new Error('Unable to create backup path for Collection \'' + collection.id + '\': ' + error)
     }
+    return this.batchCollection(collection, backupPath, logPathWithCollection, this.options.batchSize)
+  }
 
-    return collection.get()
-      .then((documentSnapshots) => documentSnapshots.docs)
-      .then((docs) => {
-        return promiseParallel(docs, (document) => {
+  batchCollection(collection: Object, backupPath: string, logPathWithCollection: string,  batchSize: number, cursor ?: Object) {
+    const batchRequested = batchSize > 0;
+    var collectionQuery = cursor ? collection.startAfter(cursor) : collection;
+    if (batchRequested) {
+      collectionQuery = collectionQuery.limit(batchSize)
+    }
+    return collectionQuery.get()
+      .then(documentSnapshots => documentSnapshots.docs)
+      .then(docs => {
+        return promiseParallel(docs, document => {
           return this.backupDocument(document, backupPath + '/' + document.id, logPathWithCollection + '/')
         }, this.options.requestCountLimit)
+        .then(() => {
+          if (batchRequested && docs.length === batchSize) {
+            return this.batchCollection(collection, backupPath, logPathWithCollection, batchSize, docs[docs.length - 1])
+          } else {
+            return Promise.resolve();
+          }
+        })
       })
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,8 @@ export type BackupOptions = {|
   prettyPrintJSON: boolean,
   requestCountLimit: number,
   exclude: Array<string>,
-  excludePatterns: Array<RegExp>
+  excludePatterns: Array<RegExp>,
+  batchSize: number
 |}
 
 export default function(_options: BackupOptions) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -18,7 +18,8 @@ export type FirestoreBackupOptions = {|
   databaseStartPath: string,
   prettyPrintJSON: boolean,
   requestCountLimit: number,
-  exclude: Array<string>
+  exclude: Array<string>,
+  batchSize: number
 |}
 
 // Returns if a value is a string


### PR DESCRIPTION
Fixes #41 

Adds an option to specify the number of documents fetched in a single request. This can help if the collection is too large to be fetched in a single request which causes the backup to fail before completion.

I called the option `batchSize`. Also left out the short flag as `-B` was already taken.